### PR TITLE
Fixes typo and adds link to PAT generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This action retrieves all `internal` repositories from your GitHub Enterprise Ac
 
 ### `enterprise`
 
-**Required** The name of the enteprise account.
+**Required** The name of the Enterprise Account.
 
 ### `token`
 
-**Required** A GitHub Personal Access Token allowing to browse the Enterprise Account. Note that this token must be allowed with all SAML enabled organizations. 
+**Required** A [GitHub Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) allowing to browse the Enterprise Account. Note that this token must be allowed with all SAML enabled organizations. 
 
 ### `outputFilename`
 


### PR DESCRIPTION
I found a mini typo and figured I would be a good citizen :)

Changes:
- fixes a typo (and makes the spelling of "Enterprise Account" consistent)
- adds link to PAT generation

One additional question:
- For the PAT, would it make sense to provide a screenshot of the exact permissions that the PAT needs in order for the Action to work? e.g. does it just need the `repo` permission or more? 